### PR TITLE
Feature/us 25 usar configs service action

### DIFF
--- a/src/pre_configs/serializers.py
+++ b/src/pre_configs/serializers.py
@@ -5,6 +5,8 @@ from utils.exceptions import InvalidPreConfigException
 
 
 class PreConfigSerializer(serializers.ModelSerializer):
+    created_config = serializers.SerializerMethodField('has_created_config')
+
     class Meta:
         model = PreConfig
         fields = (
@@ -12,10 +14,15 @@ class PreConfigSerializer(serializers.ModelSerializer):
             'name',
             'data',
             'created_at',
+            'created_config'
         )
         extra_kwargs = {
             'created_at': {'read_only': True},
+            'created_config': {'read_only': True, }
         }
+
+    def has_created_config(self, obj):
+        return len(PreConfig.objects.values('id')) > 1
 
     def validate(self, attrs):
         """

--- a/src/pre_configs/tests.py
+++ b/src/pre_configs/tests.py
@@ -1,3 +1,84 @@
-from django.test import TestCase
+from rest_framework.authtoken.models import Token
+from rest_framework.mixins import status
+from rest_framework.test import APIClient
+from rest_framework.viewsets import reverse
+
+from pre_configs.models import PreConfig
+from utils.tests import APITestCaseExpanded
 
 # Create your tests here.
+
+
+def _get_product_detail(*args):
+    return reverse("product-detail", args=args)
+
+
+class TestUnauthenticatedConfigEndpoints(APITestCaseExpanded):
+    def setUp(self):
+        self.request = APIClient()
+        self.org = self.get_organization()
+        self.prod = self.get_product(self.org)
+
+    def test_that_unauthorized_is_prohibited(self):
+        response = self.request.get(_get_product_detail(self.org.id, self.prod.id))
+        self.assertIsNotNone(self.org.id)
+        self.assertIsNotNone(self.prod.id)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestConfigEnpoints(APITestCaseExpanded):
+    def setUp(self):
+        self.request = APIClient()
+        self.user = self.get_or_create_test_user()
+        self.token = Token.objects.create(user=self.user)
+        self.request.force_authenticate(user=self.user, token=self.token)
+        self.org = self.get_organization()
+        self.prod = self.get_product(self.org)
+
+    def test_user_not_created_configs(self):
+        detail_items = self.request.get(_get_product_detail(self.org.id, self.prod.id))
+        pre_config_uri = detail_items.json()["actions"]
+        self.assertIsNotNone(pre_config_uri)
+
+        configs_resp = self.request.get(pre_config_uri["get current pre-config"])
+
+        self.assertEquals(configs_resp.status_code, status.HTTP_200_OK)
+        self.assertFalse(configs_resp.json()["created_config"])
+
+    def test_user_created_configs(self):
+        detail_items = self.request.get(_get_product_detail(self.org.id, self.prod.id))
+        pre_config_uri = detail_items.json()["actions"]
+
+        measures = [{"key": "passed_tests", "weight": 100}]
+        subcharacteristics = [
+            {"key": "testing_status", "weight": 100, "measures": measures}
+        ]
+        characteristics = [
+            {
+                "key": "reliability",
+                "weight": 100,
+                "subcharacteristics": subcharacteristics,
+            }
+        ]
+
+        data = {"name": "Test Pre-Config", "data": {"characteristics": characteristics}}
+        response = self.request.post(
+            pre_config_uri["create a new pre-config"], data, format="json"
+        )
+
+        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+
+        configs_resp = self.request.get(pre_config_uri["get current pre-config"])
+        print(configs_resp.json())
+
+        self.assertIn(
+            dict(
+                filter(
+                    lambda item_tuple: item_tuple[0] == "id",
+                    configs_resp.json().items(),
+                )
+            ),
+            PreConfig.objects.values("id").filter(id=configs_resp.json()["id"]),
+        )
+        self.assertEquals(configs_resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(configs_resp.json()["created_config"])


### PR DESCRIPTION
# Verificação de configuração criada

## Descrição

Cria checagem para diferenciar pre-configuração de uma configuração finalizada pelo usuário (mesmo que seja igual a pré-configuração)

Relacina-se a [US25](https://github.com/fga-eps-mds/2023-1-MeasureSoftGram-Doc/issues/101)
por meio da task [[Task] US - 25 - Configurações Personalizáveis pelo Service](https://github.com/fga-eps-mds/2023-1-MeasureSoftGram-Doc/issues/90)

## Porque este Pull Request é necessário?
Para que a Action do msgram possa verificar se o usuário passou pelo flxo de criação de  configuração para uma dada release.

## Critérios de aceitação

1.  [x] Deve-se informar o usuário caso não tenha feito a confiruração da release;

Closes None
